### PR TITLE
Fixing unit test to use latest methods from datamodel dependency.

### DIFF
--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/FilePaymentFileValidationsControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/FilePaymentFileValidationsControllerTest.java
@@ -143,7 +143,7 @@ public class FilePaymentFileValidationsControllerTest {
         String fileContent = getFileContent(paymentFileType);
         String intentId = IntentType.PAYMENT_FILE_CONSENT.generateIntentId();
         PaymentFile paymentFile = PaymentFileFactory.createPaymentFile(paymentFileType, fileContent);
-        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(intentId);
+        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(paymentFileType.getFileType(), HashUtils.computeSHA256FullHash(fileContent), String.valueOf(paymentFile.getNumberOfTransactions()), paymentFile.getControlSum());
         OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
         initiation.setFileHash(wrongFileHash);
         initiation.setControlSum(BigDecimal.ONE);
@@ -205,7 +205,7 @@ public class FilePaymentFileValidationsControllerTest {
         String fileContent = getFileContent(paymentFileType);
         String intentId = IntentType.PAYMENT_FILE_CONSENT.generateIntentId();
         PaymentFile paymentFile = PaymentFileFactory.createPaymentFile(paymentFileType, fileContent);
-        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(intentId);
+        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(paymentFileType.getFileType(), HashUtils.computeSHA256FullHash(fileContent), String.valueOf(paymentFile.getNumberOfTransactions()), paymentFile.getControlSum());
         OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
         initiation.setFileHash(wrongFileHash);
         initiation.setControlSum(BigDecimal.ONE);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/FilePaymentConsentValidationTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/FilePaymentConsentValidationTest.java
@@ -15,9 +15,12 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
 
+import com.forgerock.securebanking.openbanking.uk.rs.common.filepayment.PaymentFileType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+
+import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsent3;
@@ -33,7 +36,7 @@ public class FilePaymentConsentValidationTest {
     @BeforeEach
     public void setup() {
         validation = new FilePaymentConsentValidation();
-        consent3 = aValidOBWriteFileConsent3();
+        consent3 = aValidOBWriteFileConsent3(PaymentFileType.UK_OBIE_PAIN_001.getFileType(), "fileHash", "3", BigDecimal.ONE);
     }
 
     @Test

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/FilePaymentFileValidationServiceTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/FilePaymentFileValidationServiceTest.java
@@ -66,9 +66,9 @@ public class FilePaymentFileValidationServiceTest {
         // Given
         String consentId = IntentType.PAYMENT_FILE_CONSENT.generateIntentId();
         String fileContent = getFileContent(paymentFileType);
-        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(consentId);
-        OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
         PaymentFile paymentFile = PaymentFileFactory.createPaymentFile(paymentFileType, fileContent);
+        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(paymentFileType.getFileType(), HashUtils.computeSHA256FullHash(fileContent), String.valueOf(paymentFile.getNumberOfTransactions()), paymentFile.getControlSum());
+        OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
         initiation.setFileHash(HashUtils.computeSHA256FullHash(fileContent));
         initiation.setControlSum(paymentFile.getControlSum());
         initiation.setFileType(paymentFileType.getFileType());
@@ -89,9 +89,10 @@ public class FilePaymentFileValidationServiceTest {
         // Given
         String consentId = IntentType.PAYMENT_FILE_CONSENT.generateIntentId();
         String fileContent = getFileContent(paymentFileType);
-        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(consentId);
-        OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
         PaymentFile paymentFile = PaymentFileFactory.createPaymentFile(paymentFileType, fileContent);
+        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(paymentFileType.getFileType(), HashUtils.computeSHA256FullHash(fileContent), String.valueOf(paymentFile.getNumberOfTransactions()), paymentFile.getControlSum());
+        OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
+
         initiation.setFileHash(HashUtils.computeSHA256FullHash(fileContent));
         initiation.setControlSum(BigDecimal.ONE);
         initiation.setFileType(paymentFileType.getFileType());
@@ -119,9 +120,10 @@ public class FilePaymentFileValidationServiceTest {
         String wrongHash = UUID.randomUUID().toString();
         String consentId = IntentType.PAYMENT_FILE_CONSENT.generateIntentId();
         String fileContent = getFileContent(paymentFileType);
-        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(consentId);
-        OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
         PaymentFile paymentFile = PaymentFileFactory.createPaymentFile(paymentFileType, fileContent);
+        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(paymentFileType.getFileType(), HashUtils.computeSHA256FullHash(fileContent), String.valueOf(paymentFile.getNumberOfTransactions()), paymentFile.getControlSum());
+        OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
+
         initiation.setFileHash(wrongHash);
         initiation.setControlSum(paymentFile.getControlSum());
         initiation.setFileType(paymentFileType.getFileType());
@@ -148,9 +150,10 @@ public class FilePaymentFileValidationServiceTest {
         // Given
         String consentId = IntentType.PAYMENT_FILE_CONSENT.generateIntentId();
         String fileContent = getFileContent(paymentFileType);
-        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(consentId);
-        OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
         PaymentFile paymentFile = PaymentFileFactory.createPaymentFile(paymentFileType, fileContent);
+        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(paymentFileType.getFileType(), HashUtils.computeSHA256FullHash(fileContent), String.valueOf(paymentFile.getNumberOfTransactions()), paymentFile.getControlSum());
+        OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
+
         initiation.setFileHash(HashUtils.computeSHA256FullHash(fileContent));
         initiation.setControlSum(paymentFile.getControlSum());
         initiation.setFileType(paymentFileType.getFileType());
@@ -178,9 +181,10 @@ public class FilePaymentFileValidationServiceTest {
         String wrongHash = UUID.randomUUID().toString();
         String consentId = IntentType.PAYMENT_FILE_CONSENT.generateIntentId();
         String fileContent = getFileContent(paymentFileType);
-        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(consentId);
-        OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
         PaymentFile paymentFile = PaymentFileFactory.createPaymentFile(paymentFileType, fileContent);
+        OBWriteFileConsentResponse4 consentResponse4 = OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsentResponse4(paymentFileType.getFileType(), HashUtils.computeSHA256FullHash(fileContent), String.valueOf(paymentFile.getNumberOfTransactions()), paymentFile.getControlSum());
+        OBWriteFile2DataInitiation initiation = consentResponse4.getData().getInitiation();
+
         initiation.setFileHash(wrongHash);
         initiation.setControlSum(BigDecimal.ONE);
         initiation.setFileType(paymentFileType.getFileType());


### PR DESCRIPTION
Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/716

Fixed datamodel method references to use proper definitions and parameters for method calls.