### PR TITLE
637: vrp consent decision accountId

### DIFF
--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApi.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApi.java
@@ -77,11 +77,11 @@ public interface AccountsApi {
      *         Indicates the name of account identifier to filter the account identifiers. Defaults to false.
      * @param accountIdentifierIdentification
      *         Indicates the identification of account identifier to filter the account identifiers. Defaults to false.
-     * @param accountIdentifierSchemaName
+     * @param accountIdentifierSchemeName
      *         Indicates the schema name of account identifier to filter the account identifiers. Defaults to false.
      * @return a {@link FRAccountIdentifier} instance if found, or void otherwise.
      */
-    @ApiOperation(value = "Get User Account identifier filtered by name, identification and schema name",
+    @ApiOperation(value = "Get User Account with balance filtered by name, identification and schema name",
             nickname = "getUserAccountIdentifier",
             notes = "", response = FRAccountIdentifier.class,
             tags = {"Get User Account identifier",})
@@ -98,14 +98,15 @@ public interface AccountsApi {
     @RequestMapping(value = "/search/findByAccountIdentifiers",
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
-    ResponseEntity<FRAccountIdentifier> getAccountIdentifier(
-            @ApiParam(value = "The ID of the PSU who owns the account.")
-            @RequestParam(value = "userId") String userId,
+    ResponseEntity<FRAccountWithBalance> getAccountWithBalanceByIdentifiers(
+            @ApiParam(value = "The ID of the PSU who owns the account. (non mandatory)")
+            @RequestParam(value = "userId", required = false) String userId,
             @ApiParam(value = "Indicates the name of account identifier to filter the account identifiers. Defaults to false.")
             @RequestParam(value = "name", defaultValue = "false") String accountIdentifierName,
             @ApiParam(value = "Indicates the identification of account identifier to filter the account identifiers. Defaults to false.")
             @RequestParam(value = "identification", defaultValue = "false") String accountIdentifierIdentification,
             @ApiParam(value = "Indicates the schema name of account identifier to filter the account identifiers. Defaults to false.")
-            @RequestParam(value = "schemaName", defaultValue = "false") String accountIdentifierSchemaName
+            @RequestParam(value = "schemeName", defaultValue = "false") String accountIdentifierSchemeName
     );
+
 }

--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApi.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApi.java
@@ -21,6 +21,7 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.account;
 
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.common.FRAccountIdentifier;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -66,5 +67,45 @@ public interface AccountsApi {
             @RequestParam(value = "userId") String userId,
             @ApiParam(value = "Indicates if the account's balance(s) should be returned. Defaults to false.")
             @RequestParam(value = "withBalance", required = false, defaultValue = "false") boolean withBalance
+    );
+
+    /**
+     * Retrieves a user's bank account details, including it's associated balance(s) (if requested).
+     * @param userId
+     *         The ID of the user who owns the account
+     * @param accountIdentifierName
+     *         Indicates the name of account identifier to filter the account identifiers. Defaults to false.
+     * @param accountIdentifierIdentification
+     *         Indicates the identification of account identifier to filter the account identifiers. Defaults to false.
+     * @param accountIdentifierSchemaName
+     *         Indicates the schema name of account identifier to filter the account identifiers. Defaults to false.
+     * @return a {@link FRAccountIdentifier} instance if found, or void otherwise.
+     */
+    @ApiOperation(value = "Get User Account identifier filtered by name, identification and schema name",
+            nickname = "getUserAccountIdentifier",
+            notes = "", response = FRAccountIdentifier.class,
+            tags = {"Get User Account identifier",})
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "User Accounts With Balance", response = FRAccountWithBalance.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Forbidden", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
+    @RequestMapping(value = "/search/findByAccountIdentifiers",
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.GET)
+    ResponseEntity<FRAccountIdentifier> getAccountIdentifier(
+            @ApiParam(value = "The ID of the PSU who owns the account.")
+            @RequestParam(value = "userId") String userId,
+            @ApiParam(value = "Indicates the name of account identifier to filter the account identifiers. Defaults to false.")
+            @RequestParam(value = "name", defaultValue = "false") String accountIdentifierName,
+            @ApiParam(value = "Indicates the identification of account identifier to filter the account identifiers. Defaults to false.")
+            @RequestParam(value = "identification", defaultValue = "false") String accountIdentifierIdentification,
+            @ApiParam(value = "Indicates the schema name of account identifier to filter the account identifiers. Defaults to false.")
+            @RequestParam(value = "schemaName", defaultValue = "false") String accountIdentifierSchemaName
     );
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/account/AccountsApiController.java
@@ -17,6 +17,7 @@ package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.account;
 
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRAccountWithBalance;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRCashBalance;
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.common.FRAccountIdentifier;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.FRAccount;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.FRBalance;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.accounts.accounts.FRAccountRepository;
@@ -74,6 +75,25 @@ public class AccountsApiController implements AccountsApi {
                 .collect(toList())
         );
 
+    }
+
+    @Override
+    public ResponseEntity<FRAccountIdentifier> getAccountIdentifier(
+            String userId,
+            String accountIdentifierName,
+            String accountIdentifierIdentification,
+            String accountIdentifierSchemaName
+    ) {
+        log.info(
+                "Read all account identifier for user ID '{}', with name: {}, identification {} and schema name {}",
+                userId, accountIdentifierName, accountIdentifierIdentification, accountIdentifierSchemaName
+        );
+
+        FRAccountIdentifier accountIdentifierFound = accountsRepository.byUserIdAndAccountIdentifiers(
+                userId, accountIdentifierName, accountIdentifierIdentification, accountIdentifierSchemaName
+        );
+
+        return ResponseEntity.ok(accountIdentifierFound);
     }
 
     private FRAccountWithBalance toFRAccountWithBalance(FRAccount account, Map<String, List<FRBalance>> balanceMap) {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/filepayments/FilePaymentFileValidationsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/filepayments/FilePaymentFileValidationsController.java
@@ -99,6 +99,7 @@ public class FilePaymentFileValidationsController implements FilePaymentFileVali
         if (filePaymentFileValidationService.getErrors().isEmpty()) {
             return ResponseEntity.ok().build();
         } else {
+            log.error("Errors: {}", filePaymentFileValidationService.getErrors());
             throw badRequestResponseException(xFapiFinancialId, filePaymentFileValidationService.getErrors());
         }
     }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/accounts/FRAccountRepository.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/accounts/FRAccountRepository.java
@@ -16,12 +16,31 @@
 package com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.accounts.accounts;
 
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.FRAccount;
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.FRScheduledPayment;
+import org.joda.time.DateTime;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
+import java.util.List;
 
 public interface FRAccountRepository extends MongoRepository<FRAccount, String>, FRAccountRepositoryCustom {
 
     Collection<FRAccount> findByUserID(@Param("userID") String userID);
+
+    @Query("{ 'userID': ?0 , 'account.accounts.name' : ?1, 'account.accounts.identification' : ?2, 'account.accounts.schemeName': ?3}")
+    FRAccount findByUserIdAndAccountIdentifiers(
+            @Param("userID") String userID,
+            @Param("account.accounts.name") String accountIdentifierName,
+            @Param("account.accounts.identification") String accountIdentifierIdentification,
+            @Param("account.accounts.schemeName") String accountIdentifierSchemeName
+    );
+
+    @Query("{ 'account.accounts.name' : ?0, 'account.accounts.identification' : ?1, 'account.accounts.schemeName': ?2}")
+    FRAccount findByAccountIdentifiers(
+            @Param("account.accounts.name") String accountIdentifierName,
+            @Param("account.accounts.identification") String accountIdentifierIdentification,
+            @Param("account.accounts.schemeName") String accountIdentifierSchemeName
+    );
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/accounts/FRAccountRepositoryCustom.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/accounts/FRAccountRepositoryCustom.java
@@ -36,16 +36,12 @@ public interface FRAccountRepositoryCustom {
             @Param("accountId") String accountId,
             @Param("permissions") List<FRExternalPermissionsCode> permissions);
 
+    FRAccount byAccountId(
+            @Param("accountId") String accountId);
+
     List<FRAccount> byAccountIds(
             @Param("accountId") List<String> accountIds,
             @Param("permissions") List<FRExternalPermissionsCode> permissions);
 
     List<String> getUserIds(DateTime from, DateTime to);
-
-    FRAccountIdentifier byUserIdAndAccountIdentifiers(
-            @Param("userID") String userID,
-            String accountIdentifierName,
-            String accountIdentifierIdentification,
-            String accountIdentifierSchemaName
-    );
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/accounts/FRAccountRepositoryCustom.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/accounts/FRAccountRepositoryCustom.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.accounts.accounts;
 
+import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.common.FRAccountIdentifier;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.FRAccount;
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRExternalPermissionsCode;
 import org.joda.time.DateTime;
@@ -40,4 +41,11 @@ public interface FRAccountRepositoryCustom {
             @Param("permissions") List<FRExternalPermissionsCode> permissions);
 
     List<String> getUserIds(DateTime from, DateTime to);
+
+    FRAccountIdentifier byUserIdAndAccountIdentifiers(
+            @Param("userID") String userID,
+            String accountIdentifierName,
+            String accountIdentifierIdentification,
+            String accountIdentifierSchemaName
+    );
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/accounts/FRAccountRepositoryImpl.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/accounts/FRAccountRepositoryImpl.java
@@ -137,6 +137,30 @@ public class FRAccountRepositoryImpl implements FRAccountRepositoryCustom {
         return groupResults.getMappedResults().stream().map(UserIds::getUserID).collect(Collectors.toList());
     }
 
+    @Override
+    public FRAccountIdentifier byUserIdAndAccountIdentifiers(
+            String userID,
+            String accountIdentifierName,
+            String accountIdentifierIdentification,
+            String accountIdentifierSchemaName
+    ) {
+        Collection<FRAccount> accounts = accountsRepository.findByUserID(userID);
+        FRAccountIdentifier frAccountIdentifier = null;
+        for (FRAccount account : accounts) {
+            Optional<FRAccountIdentifier> optionalFRAccountIdentifier = account.getAccount().getAccounts().stream().filter(
+                    identifier -> identifier.getName().equals(accountIdentifierName) &&
+                            identifier.getIdentification().equals(accountIdentifierIdentification) &&
+                            identifier.getSchemeName().equals(accountIdentifierSchemaName)
+            ).findFirst();
+
+            if (optionalFRAccountIdentifier.isPresent()) {
+                frAccountIdentifier = optionalFRAccountIdentifier.get();
+                break;
+            }
+        }
+        return frAccountIdentifier;
+    }
+
     @Builder
     @Data
     @EqualsAndHashCode

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/accounts/FRAccountRepositoryImpl.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/accounts/FRAccountRepositoryImpl.java
@@ -85,6 +85,15 @@ public class FRAccountRepositoryImpl implements FRAccountRepositoryCustom {
     }
 
     @Override
+    public FRAccount byAccountId(String accountId) {
+        Optional<FRAccount> isAccount = accountsRepository.findById(accountId);
+        if (!isAccount.isPresent()) {
+            return null;
+        }
+        return isAccount.get();
+    }
+
+    @Override
     public List<FRAccount> byAccountIds(List<String> accountIds, List<FRExternalPermissionsCode> permissions) {
         Iterable<FRAccount> accounts = accountsRepository.findAllById(accountIds);
         try {
@@ -135,30 +144,6 @@ public class FRAccountRepositoryImpl implements FRAccountRepositoryCustom {
         AggregationResults<UserIds> groupResults
                 = mongoTemplate.aggregate(aggregation, FRAccount.class, UserIds.class);
         return groupResults.getMappedResults().stream().map(UserIds::getUserID).collect(Collectors.toList());
-    }
-
-    @Override
-    public FRAccountIdentifier byUserIdAndAccountIdentifiers(
-            String userID,
-            String accountIdentifierName,
-            String accountIdentifierIdentification,
-            String accountIdentifierSchemaName
-    ) {
-        Collection<FRAccount> accounts = accountsRepository.findByUserID(userID);
-        FRAccountIdentifier frAccountIdentifier = null;
-        for (FRAccount account : accounts) {
-            Optional<FRAccountIdentifier> optionalFRAccountIdentifier = account.getAccount().getAccounts().stream().filter(
-                    identifier -> identifier.getName().equals(accountIdentifierName) &&
-                            identifier.getIdentification().equals(accountIdentifierIdentification) &&
-                            identifier.getSchemeName().equals(accountIdentifierSchemaName)
-            ).findFirst();
-
-            if (optionalFRAccountIdentifier.isPresent()) {
-                frAccountIdentifier = optionalFRAccountIdentifier.get();
-                break;
-            }
-        }
-        return frAccountIdentifier;
     }
 
     @Builder

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/balances/FRBalanceRepository.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/persistence/repository/accounts/balances/FRBalanceRepository.java
@@ -30,6 +30,7 @@ import java.util.Set;
 public interface FRBalanceRepository extends MongoRepository<FRBalance, String>, FRBalanceRepositoryCustom {
 
     Page<FRBalance> findByAccountId(@Param("accountId") String accountId, Pageable pageable);
+    FRBalance findByAccountId(@Param("accountId") String accountId);
     Page<FRBalance> findByAccountIdIn(@Param("accountIds") List<String> accountIds, Pageable pageable);
     Collection<FRBalance> findByAccountIdIn(@Param("accountIds") List<String> accountIds);
     Optional<FRBalance> findByAccountIdAndBalanceType(@Param("accountId") String accountId, @Param("type") FRBalanceType type);


### PR DESCRIPTION
- Added method to retrieve the account identifier by identifiers
    - user id (`optional`), name, identification and schema name to validate the trusted beneficiary and update the debtor account provided in the consent with the account id if necessary (ex. VRP payments sweeping case)
Issue: https://github.com/secureapigateway/secureapigateway/issues/637