### PR TITLE
715: X-fapi-financial-id header should be optional

### DIFF
--- a/securebanking-openbanking-uk-rs-obie-api/src/main/resources/specification/3.1.10/event-notifications-openapi.yaml
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/resources/specification/3.1.10/event-notifications-openapi.yaml
@@ -38,7 +38,7 @@ components:
     x-fapi-financial-id-Param:
       in: "header"
       name: "x-fapi-financial-id"
-      required: true
+      required: false
       description: "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB."
       schema:
         type: "string"

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/resources/specification/3.1.8/event-notifications-openapi.yaml
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/resources/specification/3.1.8/event-notifications-openapi.yaml
@@ -38,7 +38,7 @@ components:
     x-fapi-financial-id-Param:
       in: "header"
       name: "x-fapi-financial-id"
-      required: true
+      required: false
       description: "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB."
       schema:
         type: "string"

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/resources/specification/3.1.9/event-notifications-openapi.yaml
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/resources/specification/3.1.9/event-notifications-openapi.yaml
@@ -38,7 +38,7 @@ components:
     x-fapi-financial-id-Param:
       in: "header"
       name: "x-fapi-financial-id"
-      required: true
+      required: false
       description: "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB."
       schema:
         type: "string"


### PR DESCRIPTION
Issue: https://github.com/secureapigateway/secureapigateway/issues/715
Description: Changed the "required" value from true to false.