### PR TITLE
715: X-fapi-financial-id header should be optional

### DIFF
--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApi.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApi.java
@@ -66,9 +66,6 @@ public interface PaymentFundsConfirmationApi {
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization") String authorization,
 
-           // @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
-           // @RequestHeader(value = "x-fapi-financial-id") String xFapiFinancialId,
-
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
             @RequestHeader(value = "x-fapi-auth-date", required = false) String xFapiAuthDate,
 

--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApi.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApi.java
@@ -66,8 +66,8 @@ public interface PaymentFundsConfirmationApi {
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization") String authorization,
 
-            @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
-            @RequestHeader(value = "x-fapi-financial-id") String xFapiFinancialId,
+           // @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
+           // @RequestHeader(value = "x-fapi-financial-id") String xFapiFinancialId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
             @RequestHeader(value = "x-fapi-auth-date", required = false) String xFapiAuthDate,

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApi.java
@@ -66,9 +66,6 @@ public interface FundsConfirmationsApi {
             @ApiParam(value = "The ID of the account to check if funds are available.", required = true)
             @RequestHeader("x-account-id") String accountId,
 
-            //@ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
-            //@RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
-
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,
 
@@ -112,9 +109,6 @@ public interface FundsConfirmationsApi {
     ResponseEntity<OBFundsConfirmationResponse1> getFundsConfirmationId(
             @ApiParam(value = "FundsConfirmationId", required = true)
             @PathVariable("FundsConfirmationId") String fundsConfirmationId,
-
-            //@ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
-            //@RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
 
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApi.java
@@ -66,8 +66,8 @@ public interface FundsConfirmationsApi {
             @ApiParam(value = "The ID of the account to check if funds are available.", required = true)
             @RequestHeader("x-account-id") String accountId,
 
-            @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
-            @RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
+            //@ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
+            //@RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
 
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,
@@ -113,8 +113,8 @@ public interface FundsConfirmationsApi {
             @ApiParam(value = "FundsConfirmationId", required = true)
             @PathVariable("FundsConfirmationId") String fundsConfirmationId,
 
-            @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
-            @RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
+            //@ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
+            //@RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
 
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
             @RequestHeader(value = "Authorization", required = true) String authorization,

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApiController.java
@@ -47,7 +47,7 @@ public class PaymentFundsConfirmationApiController implements PaymentFundsConfir
             String amount,
             String version,
             String authorization,
-            String xFapiFinancialId,
+            //String xFapiFinancialId,
             String xFapiAuthDate,
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApiController.java
@@ -47,7 +47,6 @@ public class PaymentFundsConfirmationApiController implements PaymentFundsConfir
             String amount,
             String version,
             String authorization,
-            //String xFapiFinancialId,
             String xFapiAuthDate,
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApiController.java
@@ -56,7 +56,8 @@ public class FundsConfirmationsApiController implements FundsConfirmationsApi {
     public ResponseEntity createFundsConfirmation(
             @Valid OBFundsConfirmation1 obFundsConfirmation1,
             String accountId,
-            String xFapiFinancialId, String authorization,
+            //String xFapiFinancialId,
+            String authorization,
             DateTime xFapiCustomerLastLoggedTime,
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,
@@ -92,7 +93,7 @@ public class FundsConfirmationsApiController implements FundsConfirmationsApi {
     @Override
     public ResponseEntity getFundsConfirmationId(
             String fundsConfirmationId,
-            String xFapiFinancialId,
+            //String xFapiFinancialId,
             String authorization,
             DateTime xFapiCustomerLastLoggedTime,
             String xFapiCustomerIpAddress,

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApiController.java
@@ -56,7 +56,6 @@ public class FundsConfirmationsApiController implements FundsConfirmationsApi {
     public ResponseEntity createFundsConfirmation(
             @Valid OBFundsConfirmation1 obFundsConfirmation1,
             String accountId,
-            //String xFapiFinancialId,
             String authorization,
             DateTime xFapiCustomerLastLoggedTime,
             String xFapiCustomerIpAddress,
@@ -93,7 +92,6 @@ public class FundsConfirmationsApiController implements FundsConfirmationsApi {
     @Override
     public ResponseEntity getFundsConfirmationId(
             String fundsConfirmationId,
-            //String xFapiFinancialId,
             String authorization,
             DateTime xFapiCustomerLastLoggedTime,
             String xFapiCustomerIpAddress,

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_1_3/FundsConfirmationsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_1_3/FundsConfirmationsApiController.java
@@ -51,7 +51,6 @@ public class FundsConfirmationsApiController implements FundsConfirmationsApi {
         return previousVersionController.createFundsConfirmation(
                 obFundsConfirmation1,
                 accountId,
-                //DUMMY_FINANCIAL_ID,
                 authorization,
                 xFapiAuthDate,
                 xFapiCustomerIpAddress,
@@ -74,7 +73,6 @@ public class FundsConfirmationsApiController implements FundsConfirmationsApi {
     ) {
         return previousVersionController.getFundsConfirmationId(
                 fundsConfirmationId,
-                //DUMMY_FINANCIAL_ID,
                 authorization,
                 xFapiAuthDate,
                 xFapiCustomerIpAddress,

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_1_3/FundsConfirmationsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_1_3/FundsConfirmationsApiController.java
@@ -51,7 +51,7 @@ public class FundsConfirmationsApiController implements FundsConfirmationsApi {
         return previousVersionController.createFundsConfirmation(
                 obFundsConfirmation1,
                 accountId,
-                DUMMY_FINANCIAL_ID,
+                //DUMMY_FINANCIAL_ID,
                 authorization,
                 xFapiAuthDate,
                 xFapiCustomerIpAddress,
@@ -74,7 +74,7 @@ public class FundsConfirmationsApiController implements FundsConfirmationsApi {
     ) {
         return previousVersionController.getFundsConfirmationId(
                 fundsConfirmationId,
-                DUMMY_FINANCIAL_ID,
+                //DUMMY_FINANCIAL_ID,
                 authorization,
                 xFapiAuthDate,
                 xFapiCustomerIpAddress,

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
@@ -100,7 +100,7 @@ public class HttpHeadersTestDataFactory {
         headers.setAccept(singletonList(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth("dummyAuthToken");
-        headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
+        //headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
         headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
         headers.add("x-idempotency-key", UUID.randomUUID().toString());
         headers.add("x-ob-account-id", UUID.randomUUID().toString());

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
@@ -131,7 +131,7 @@ public class HttpHeadersTestDataFactory {
         headers.setAccept(singletonList(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth("dummyAuthToken");
-        //headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
+        headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
         headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
         headers.add("x-account-id", accountId);
         headers.add("x-ob-url", resourceUrl);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
@@ -100,7 +100,7 @@ public class HttpHeadersTestDataFactory {
         headers.setAccept(singletonList(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth("dummyAuthToken");
-        //headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
+        headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
         headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
         headers.add("x-idempotency-key", UUID.randomUUID().toString());
         headers.add("x-ob-account-id", UUID.randomUUID().toString());
@@ -131,7 +131,7 @@ public class HttpHeadersTestDataFactory {
         headers.setAccept(singletonList(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth("dummyAuthToken");
-        headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
+        //headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
         headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
         headers.add("x-account-id", accountId);
         headers.add("x-ob-url", resourceUrl);


### PR DESCRIPTION
Issue: https://github.com/secureapigateway/secureapigateway/issues/715