### PR TITLE
795: Adding testdata spring config which supports configuring the AccountIds generated by the FakeDataApiController

### DIFF
--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/FakeDataApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/FakeDataApiController.java
@@ -22,6 +22,8 @@ import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.com
 import com.forgerock.securebanking.openbanking.uk.error.OBErrorException;
 import com.forgerock.securebanking.openbanking.uk.rs.api.admin.data.dto.FRUserData;
 import com.forgerock.securebanking.openbanking.uk.rs.configuration.DataConfigurationProperties;
+import com.forgerock.securebanking.openbanking.uk.rs.configuration.TestUserAccountIds;
+import com.forgerock.securebanking.openbanking.uk.rs.configuration.TestUserAccountIds.TestAccountId;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.FRAccount;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.account.*;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.accounts.accounts.FRAccountRepository;
@@ -64,6 +66,8 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.account.FRFinancialAccount.*;
 import static com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType.DATA_INVALID_REQUEST;
@@ -113,13 +117,21 @@ public class FakeDataApiController implements FakeDataApi {
     private ObjectMapper mapper;
     @Autowired
     private DataConfigurationProperties dataConfig;
+    private final Map<String, List<TestAccountId>> userAccountIds;
 
     private List<String> companies;
     private List<String> names;
 
-    public FakeDataApiController() throws IOException {
+    public FakeDataApiController(TestUserAccountIds testUserAccountIds) throws IOException {
         companies = loadCSV(new ClassPathResource(COMPANIES_CSV));
         names = loadCSV(new ClassPathResource(NAMES_CSV));
+        if (testUserAccountIds == null || testUserAccountIds.getUserAccountIds() == null) {
+            // This config is optional
+            this.userAccountIds = Map.of();
+        } else {
+            this.userAccountIds = testUserAccountIds.getUserAccountIds();
+        }
+
     }
 
     @Override
@@ -154,17 +166,15 @@ public class FakeDataApiController implements FakeDataApi {
         }
     }
 
-    private FRUserData generateRandomData(String userId, String username)
-     {
+    private FRUserData generateRandomData(String userId, String username) {
         LOGGER.debug("Generate data for user '{}'", userId);
 
-        if (accountsRepository.findByUserID(userId).size() > 0 ) {
+        if (accountsRepository.findByUserID(userId).size() > 0) {
             LOGGER.debug("User {} already have some data", userId);
         }
-        {
-            Integer sortCode = ThreadLocalRandom.current().nextInt(0, 999999);
-            Integer accountNumber = ThreadLocalRandom.current().nextInt(0, 99999999);
 
+        final Supplier<String> accountIdSupplier = createAccountIdSupplier(username);
+        {
             String accountId = UUID.randomUUID().toString();
             FRAccount accountPremierBank = new FRAccount();
             accountPremierBank.setCreated(new DateTime());
@@ -182,7 +192,7 @@ public class FakeDataApiController implements FakeDataApi {
                     .maturityDate(DateTime.now().plusDays(1))
                     .accounts(Collections.singletonList(FRAccountIdentifier.builder()
                             .schemeName(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER.toString())
-                            .identification(sortCode.toString() + accountNumber.toString())
+                            .identification(accountIdSupplier.get())
                             .name(username)
                             .secondaryIdentification(ThreadLocalRandom.current().nextInt(0, 99999999) + "")
                             .build()))
@@ -196,45 +206,39 @@ public class FakeDataApiController implements FakeDataApi {
             generateOfferLimitIncrease(accountPremierBank);
             generateOfferBalanceTransfer(accountPremierBank);
         }
-         {
-             Integer sortCode = ThreadLocalRandom.current().nextInt(0, 999999);
-             Integer accountNumber = ThreadLocalRandom.current().nextInt(0, 99999999);
-
-             String accountId = UUID.randomUUID().toString();
-             FRAccount accountPremierBank = new FRAccount();
-             accountPremierBank.setId(accountId);
-             accountPremierBank.setCreated(new DateTime());
-             accountPremierBank.setUserID(userId);
-             accountPremierBank.setAccount(builder()
-                     .accountId(accountId)
-                     .accountType(FRAccountTypeCode.PERSONAL)
-                     .accountSubType(FRAccountSubTypeCode.CURRENTACCOUNT)
-                     .currency(EUR)
-                     .nickname("FR Bills")
-                     .status(FRAccountStatusCode.ENABLED)
-                     .statusUpdateDateTime(DateTime.now())
-                     .openingDate(DateTime.now().minusDays(1))
-                     .maturityDate(DateTime.now().plusDays(1))
-                     .accounts(Collections.singletonList(FRAccountIdentifier.builder()
-                             .schemeName(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER.toString())
-                             .identification(sortCode.toString() + accountNumber.toString())
-                             .name(username)
-                             .secondaryIdentification(ThreadLocalRandom.current().nextInt(0, 99999999) + "")
-                             .build()))
-                     .build()
-             );
-
-             LOGGER.debug("Account '{}' generated for user '{}'", accountPremierBank, userId);
-             accountsRepository.save(accountPremierBank);
-             generateAccountData(accountPremierBank);
-             generateParty(accountPremierBank, username);
-             generateOfferLimitIncrease(accountPremierBank);
-             generateOfferBalanceTransfer(accountPremierBank);
-         }
         {
-            Integer sortCode = ThreadLocalRandom.current().nextInt(0, 999999);
-            Integer accountNumber = ThreadLocalRandom.current().nextInt(0, 99999999);
+            String accountId = UUID.randomUUID().toString();
+            FRAccount accountPremierBank = new FRAccount();
+            accountPremierBank.setId(accountId);
+            accountPremierBank.setCreated(new DateTime());
+            accountPremierBank.setUserID(userId);
+            accountPremierBank.setAccount(builder()
+                    .accountId(accountId)
+                    .accountType(FRAccountTypeCode.PERSONAL)
+                    .accountSubType(FRAccountSubTypeCode.CURRENTACCOUNT)
+                    .currency(EUR)
+                    .nickname("FR Bills")
+                    .status(FRAccountStatusCode.ENABLED)
+                    .statusUpdateDateTime(DateTime.now())
+                    .openingDate(DateTime.now().minusDays(1))
+                    .maturityDate(DateTime.now().plusDays(1))
+                    .accounts(Collections.singletonList(FRAccountIdentifier.builder()
+                            .schemeName(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER.toString())
+                            .identification(accountIdSupplier.get())
+                            .name(username)
+                            .secondaryIdentification(ThreadLocalRandom.current().nextInt(0, 99999999) + "")
+                            .build()))
+                    .build()
+            );
 
+            LOGGER.debug("Account '{}' generated for user '{}'", accountPremierBank, userId);
+            accountsRepository.save(accountPremierBank);
+            generateAccountData(accountPremierBank);
+            generateParty(accountPremierBank, username);
+            generateOfferLimitIncrease(accountPremierBank);
+            generateOfferBalanceTransfer(accountPremierBank);
+        }
+        {
             String accountId = UUID.randomUUID().toString();
             FRAccount accountPremierCard = new FRAccount();
             accountPremierCard.setCreated(new DateTime());
@@ -252,7 +256,7 @@ public class FakeDataApiController implements FakeDataApi {
                     .maturityDate(DateTime.now().plusDays(1))
                     .accounts(Collections.singletonList(FRAccountIdentifier.builder()
                             .schemeName(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER.toString())
-                            .identification(sortCode.toString() + accountNumber.toString())
+                            .identification(accountIdSupplier.get())
                             .name(username)
                             .build()))
                     .build()
@@ -267,7 +271,35 @@ public class FakeDataApiController implements FakeDataApi {
         generateGlobalParty(userId, username);
 
         return dataController.exportUserData(userId).getBody();
-     }
+    }
+
+    Supplier<String> createAccountIdSupplier(String username) {
+        // Allow the AccountIds to be sourced from configuration, default to a randomly generated numbers
+        final List<TestAccountId> accountIds = userAccountIds.get(username);
+        if (accountIds == null) {
+            return this::generateRandomAccountNumber;
+        } else {
+            final AtomicInteger accountIdsIndex = new AtomicInteger(0);
+            return () -> {
+                final int index = accountIdsIndex.getAndIncrement();
+                if (index < accountIds.size()) {
+                    final TestAccountId accountId = accountIds.get(index);
+                    return accountId.getSortCode() + accountId.getAccountNumber();
+                } else {
+                    return generateRandomAccountNumber();
+                }
+            };
+        }
+    }
+
+    private String generateRandomAccountNumber() {
+        final ThreadLocalRandom random = ThreadLocalRandom.current();
+        // 6-digit sort code
+        final int sortCode = random.nextInt(100000, 999999);
+        // 8-digit account number
+        final int accountNumber = ThreadLocalRandom.current().nextInt(10000000, 99999999);
+        return new StringBuilder().append(sortCode).append(accountNumber).toString();
+    }
 
     private void generateAccountData(FRAccount account) {
         FRBalance balance = generateBalance(account, FRCreditDebitIndicator.DEBIT, null);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/FakeDataApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/FakeDataApiController.java
@@ -117,6 +117,7 @@ public class FakeDataApiController implements FakeDataApi {
     private ObjectMapper mapper;
     @Autowired
     private DataConfigurationProperties dataConfig;
+
     private final Map<String, List<TestAccountId>> userAccountIds;
 
     private List<String> companies;
@@ -277,8 +278,10 @@ public class FakeDataApiController implements FakeDataApi {
         // Allow the AccountIds to be sourced from configuration, default to a randomly generated numbers
         final List<TestAccountId> accountIds = userAccountIds.get(username);
         if (accountIds == null) {
+            LOGGER.debug("Using random accountId supplier for user: {}", username);
             return this::generateRandomAccountNumber;
         } else {
+            LOGGER.debug("Using config driven accountId supplier for user: {}", username);
             final AtomicInteger accountIdsIndex = new AtomicInteger(0);
             return () -> {
                 final int index = accountIdsIndex.getAndIncrement();

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/TestUserAccountIds.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/TestUserAccountIds.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.forgerock.securebanking.openbanking.uk.rs.configuration;
 
 import java.util.List;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/TestUserAccountIds.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/TestUserAccountIds.java
@@ -1,0 +1,44 @@
+package com.forgerock.securebanking.openbanking.uk.rs.configuration;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration class representing Test User AccountId data
+ */
+@Configuration
+@ConfigurationProperties(prefix = "testdata")
+public class TestUserAccountIds {
+    private Map<String, List<TestAccountId>> userAccountIds;
+
+    public void setUserAccountIds(Map<String, List<TestAccountId>> userAccountIds) {
+        this.userAccountIds = userAccountIds;
+    }
+
+    public Map<String, List<TestAccountId>> getUserAccountIds() {
+        return userAccountIds;
+    }
+
+    public static class TestAccountId {
+        private String sortCode;
+        private String accountNumber;
+
+        public String getAccountNumber() {
+            return accountNumber;
+        }
+        public String getSortCode() {
+            return sortCode;
+        }
+
+        public void setAccountNumber(String accountNumber) {
+            this.accountNumber = accountNumber;
+        }
+
+        public void setSortCode(String sortCode) {
+            this.sortCode = sortCode;
+        }
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/TestUserAccountIds.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/TestUserAccountIds.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConfigurationProperties(prefix = "testdata")
 public class TestUserAccountIds {
+
     private Map<String, List<TestAccountId>> userAccountIds;
 
     public void setUserAccountIds(Map<String, List<TestAccountId>> userAccountIds) {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/FakeDataApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/FakeDataApiControllerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.forgerock.securebanking.openbanking.uk.rs.api.admin.data;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/FakeDataApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/admin/data/FakeDataApiControllerTest.java
@@ -1,0 +1,52 @@
+package com.forgerock.securebanking.openbanking.uk.rs.api.admin.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class FakeDataApiControllerTest {
+
+    private static final String TEST_USERNAME = "psu4test";
+    @Autowired
+    private FakeDataApiController fakeDataApiController;
+
+    @Test
+    void testAccountIdGenerationForUserWithConfig() {
+        final Supplier<String> accountIdSupplier = fakeDataApiController.createAccountIdSupplier(TEST_USERNAME);
+        // verify we get the 3 preconfigured accountIds
+        assertEquals("01233243245676", accountIdSupplier.get());
+        assertEquals("01233254312390", accountIdSupplier.get());
+        assertEquals("33441230187862", accountIdSupplier.get());
+
+        // verify we get random accountIds after the preconfigured accountIds are exhausted
+        verifySupplierGeneratesRandomIds(accountIdSupplier);
+    }
+
+    @Test
+    void testAccountIdGenerationForUserWithoutConfig() {
+        final Supplier<String> accountIdSupplier = fakeDataApiController.createAccountIdSupplier("newUser123");
+        verifySupplierGeneratesRandomIds(accountIdSupplier);
+    }
+
+    private static void verifySupplierGeneratesRandomIds(Supplier<String> accountIdSupplier) {
+        final Set<String> randomAccountIds = new HashSet<>();
+        final int numRandomAccountIds = 10;
+        for (int i = 0; i < numRandomAccountIds; i++) {
+            final String randomAccountId = accountIdSupplier.get();
+            assertEquals(14, randomAccountId.length());
+            randomAccountIds.add(randomAccountId);
+        }
+        assertEquals(numRandomAccountIds, randomAccountIds.size());
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/resources/application-test.yml
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/resources/application-test.yml
@@ -49,3 +49,13 @@ swagger:
   contact-url: https://www.forgerock.com/
   docket-apis-basePackage: com.forgerock.securebanking.openbanking.uk.rs.api.obie
   docket-paths-selector-regex: /open-banking/v(\d+.)?(\d+.)?(\*|\d+)
+
+testdata:
+  userAccountIds:
+    psu4test:
+        - sortCode: "012332"
+          accountNumber: "43245676"
+        - sortCode: "012332"
+          accountNumber: "54312390"
+        - sortCode: "334412"
+          accountNumber: "30187862"


### PR DESCRIPTION
New configuration allows test AccountIds to be configured for usernames. When FakeDataApiController generates test data for a user, it will check if there are preconfigured AccountIds and use these in order they appear in the config file.

The configuration is optional. It may be completely omitted, or have no configuration for a particular username. In this case the AccountIds are generated randomly. For usernames with configuration, random AccountIds will also be produced when the configured list of ids is exhausted.

Making this change allows us to have random test data with predictable AccountIds, which makes testing easier by allowing us to specify known AccountIds in requests which require a DebtorAccount to be supplied.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/795