### PR TITLE
239: Call IG internal svc address to access consent repo

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -56,11 +56,11 @@ spec:
             value: {{ .Values.deployment.server.port | quote }}
           - name: EXPECTED_ORIGIN_ENDS
             value: {{ .Values.deployment.cors.originEnds }}
-          - name: IG_FQDN
+          - name: CONSENT_REPO_HOST
             valueFrom:
               configMapKeyRef:
                 name: securebanking-platform-config
-                key: IG_FQDN
+                key: IG_INTERNAL_SVC
           - name: IDENTITY_PLATFORM_FQDN
             valueFrom:
               configMapKeyRef:

--- a/securebanking-forgerock-rs-platform-client/src/main/java/com/forgerock/securebanking/rs/platform/client/configuration/ConsentRepoConfiguration.java
+++ b/securebanking-forgerock-rs-platform-client/src/main/java/com/forgerock/securebanking/rs/platform/client/configuration/ConsentRepoConfiguration.java
@@ -16,21 +16,20 @@
 package com.forgerock.securebanking.rs.platform.client.configuration;
 
 import lombok.Data;
-import org.springframework.beans.factory.annotation.Value;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 
-import java.net.URI;
 import java.util.Map;
 
 @Configuration
-@ConfigurationProperties(prefix = "identity-platform.client")
+@ConfigurationProperties(prefix = "consent-repo.client")
 @Data
-public class ConfigurationPropertiesClient {
-    private String igFqdn;
-    private String identityPlatformFqdn;
-    @Value("${scheme:https}")
+public class ConsentRepoConfiguration {
+
+    private String host;
+    private int port;
     private String scheme;
     /*
      * Spring maps the properties, the keys from file will be the map keys
@@ -41,13 +40,8 @@ public class ConfigurationPropertiesClient {
      */
     private Map<String, String> contextsRepoConsent = new LinkedCaseInsensitiveMap<>();
 
-    private static final String _delimiter = "://";
 
-    public String getIgFqdnURIAsString() {
-        return String.join(_delimiter, scheme, igFqdn);
-    }
-
-    public URI getIgFqdnURI() {
-        return URI.create(String.join(_delimiter, scheme, igFqdn));
+    public String getConsentRepoBaseUri() {
+        return new StringBuilder(128).append(scheme).append("://").append(host).append(':').append(port).toString();
     }
 }

--- a/securebanking-forgerock-rs-platform-client/src/main/java/com/forgerock/securebanking/rs/platform/client/services/CloudPlatformClientService.java
+++ b/securebanking-forgerock-rs-platform-client/src/main/java/com/forgerock/securebanking/rs/platform/client/services/CloudPlatformClientService.java
@@ -16,7 +16,7 @@
 package com.forgerock.securebanking.rs.platform.client.services;
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.share.IntentType;
-import com.forgerock.securebanking.rs.platform.client.configuration.ConfigurationPropertiesClient;
+import com.forgerock.securebanking.rs.platform.client.configuration.ConsentRepoConfiguration;
 import com.forgerock.securebanking.rs.platform.client.exceptions.ErrorClient;
 import com.forgerock.securebanking.rs.platform.client.exceptions.ErrorType;
 import com.forgerock.securebanking.rs.platform.client.exceptions.ExceptionClient;
@@ -46,9 +46,9 @@ class CloudPlatformClientService implements PlatformClient {
 
     private static final String IDM_RESPOND_OB_INTENT_OBJECT_FIELD = "OBIntentObject";
     private final RestTemplate restTemplate;
-    private final ConfigurationPropertiesClient configurationProperties;
+    private final ConsentRepoConfiguration configurationProperties;
 
-    public CloudPlatformClientService(RestTemplate restTemplate, ConfigurationPropertiesClient configurationProperties) {
+    public CloudPlatformClientService(RestTemplate restTemplate, ConsentRepoConfiguration configurationProperties) {
         this.restTemplate = restTemplate;
         this.configurationProperties = configurationProperties;
     }
@@ -99,7 +99,7 @@ class CloudPlatformClientService implements PlatformClient {
                     errorMessage
             );
         }
-        consentURL = configurationProperties.getIgFqdnURIAsString() +
+        consentURL = configurationProperties.getConsentRepoBaseUri() +
                 UrlContext.replaceParameterContextIntentId(
                         configurationProperties.getContextsRepoConsent().get(httpMethod.name()),
                         intentId

--- a/securebanking-forgerock-rs-platform-client/src/test/java/com/forgerock/securebanking/rs/platform/client/configuration/ConsentRepoConfigurationTest.java
+++ b/securebanking-forgerock-rs-platform-client/src/test/java/com/forgerock/securebanking/rs/platform/client/configuration/ConsentRepoConfigurationTest.java
@@ -27,22 +27,19 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit test for {@link ConfigurationPropertiesClient}
+ * Unit test for {@link ConsentRepoConfiguration}
  */
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {ConfigurationPropertiesClient.class}, initializers = ConfigFileApplicationContextInitializer.class)
-@EnableConfigurationProperties(value = ConfigurationPropertiesClient.class)
+@ContextConfiguration(classes = {ConsentRepoConfiguration.class}, initializers = ConfigFileApplicationContextInitializer.class)
+@EnableConfigurationProperties(value = ConsentRepoConfiguration.class)
 @ActiveProfiles("test")
-public class ConfigurationPropertiesClientTest {
+public class ConsentRepoConfigurationTest {
 
     @Autowired
-    private ConfigurationPropertiesClient configurationPropertiesClient;
+    private ConsentRepoConfiguration consentRepoConfiguration;
 
     @Test
-    public void shouldHaveAllProperties(){
-        assertThat(configurationPropertiesClient.getIgFqdn()).isNotNull();
-        assertThat(configurationPropertiesClient.getIdentityPlatformFqdn()).isNotNull();
-        assertThat(configurationPropertiesClient.getScheme()).isNotNull();
-        assertThat(configurationPropertiesClient.getContextsRepoConsent()).isNotEmpty();
+    public void shouldConfigureIgBaseUri(){
+        assertThat(consentRepoConfiguration.getConsentRepoBaseUri()).isEqualTo("http://ig:80");
     }
 }

--- a/securebanking-forgerock-rs-platform-client/src/test/java/com/forgerock/securebanking/rs/platform/client/services/PlatformClientServiceTest.java
+++ b/securebanking-forgerock-rs-platform-client/src/test/java/com/forgerock/securebanking/rs/platform/client/services/PlatformClientServiceTest.java
@@ -16,7 +16,7 @@
 package com.forgerock.securebanking.rs.platform.client.services;
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.share.IntentType;
-import com.forgerock.securebanking.rs.platform.client.configuration.ConfigurationPropertiesClient;
+import com.forgerock.securebanking.rs.platform.client.configuration.ConsentRepoConfiguration;
 import com.forgerock.securebanking.rs.platform.client.exceptions.ErrorType;
 import com.forgerock.securebanking.rs.platform.client.exceptions.ExceptionClient;
 import com.forgerock.securebanking.rs.platform.client.model.ClientRequest;
@@ -55,7 +55,7 @@ public class PlatformClientServiceTest {
     private CloudPlatformClientService consentService;
 
     @Mock
-    protected ConfigurationPropertiesClient configurationPropertiesClient;
+    protected ConsentRepoConfiguration configurationPropertiesClient;
 
     @Mock
     protected RestTemplate restTemplate;

--- a/securebanking-forgerock-rs-platform-client/src/test/resources/application-test.yml
+++ b/securebanking-forgerock-rs-platform-client/src/test/resources/application-test.yml
@@ -1,10 +1,10 @@
-identity-platform:
+consent-repo:
   client:
-    ig_fqdn: ${IG_FQDN:https://obdemo.dev.forgerock.financial}
-    identity_platform_fqdn: ${IDENTITY_PLATFORM_FQDN:https://iam.dev.forgerock.financial}
+    scheme: http
+    host: ${CONSENT_REPO_HOST:ig}
+    port: 80
     contexts_repo_consent:
       get: /repo/consents/@IntentId@
       put: /repo/consents/@IntentId@
       patch: /repo/consents/@IntentId@
       delete: /repo/consents/@IntentId@
-    scheme: https


### PR DESCRIPTION
The IG Consent Repo (/repo route), is an internal feature. Use the internal IG address to access it, so that the ingress rule can be removed.

Note: In future the /repo route will be removed in favour of a dedicated consent API

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/239